### PR TITLE
🐛 Compile `spectacle-theme-*` inside module forlder.

### DIFF
--- a/lib/template/index.js
+++ b/lib/template/index.js
@@ -20,7 +20,7 @@ const theme = createTheme({});
 // --- SYNTAX HIGHLIGHTING ---
 // import 'prismjs/components/prism-core';
 // import 'prismjs/components/prism-clike';
-// import 'prismjs/components/javascript';
+// import 'prismjs/components/prism-javascript';
 
 // --- IMAGES ---
 // Import/require your images and add them to `images`

--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -1,58 +1,69 @@
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
-const { dirname } = require('path');
 const paths = require('./paths');
 const pkg = require(paths.package);
 const presentation = require.resolve('./presentation');
 
-
 /**
  * Base Webpack configuration.
  */
-module.exports = function createConfig (entry, include) {
+module.exports = function createConfig(entry, include) {
   return {
     devtool: 'eval',
     entry: [entry],
     output: {
       path: paths.build,
       filename: 'bundle.js',
-      pathinfo: true
+      pathinfo: true,
     },
     resolve: {
       extensions: ['.js', '.json', '.jsx', ''],
       alias: {
-        melodrama: presentation
-      }
+        melodrama: presentation,
+      },
     },
     module: {
-      loaders: [{
-        test: /\.md$/,
-        loader: 'html!markdown?gfm=false'
-      }, {
-        test: /\.(js|jsx)$/,
-        loader: 'babel',
-        include: [entry, paths.framework, ...include],
-        query: {
-          presets: ['react', 'es2015', 'stage-0'],
-          babelrc: false,
-          compact: false
-        }
-      }, {
-        test: /\.css$/,
-        loader: 'style!css'
-      }, {
-        test: /\.json$/,
-        loader: 'json'
-      }, {
-        test: /\.(ico|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)$/,
-        loader: 'file'
-      }]
+      loaders: [
+        {
+          test: /\.md$/,
+          loader: 'html!markdown?gfm=false',
+        },
+        {
+          test: /\.(js|jsx)$/,
+          loader: 'babel',
+          include: [
+            entry,
+            paths.framework,
+            /node_modules\/spectacle-theme-.*/,
+            ...include,
+          ],
+          query: {
+            presets: ['react', 'es2015', 'stage-0'],
+            babelrc: false,
+            compact: false,
+          },
+        },
+        {
+          test: /\.css$/,
+          loader: 'style!css',
+        },
+        {
+          test: /\.json$/,
+          loader: 'json',
+        },
+        {
+          test: /\.(ico|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)$/,
+          loader: 'file',
+        },
+      ],
     },
     plugins: [
       new CaseSensitivePathsPlugin(),
       new HtmlWebpackPlugin({
-        title: `Slides | ${pkg.name.replace(/[-]/g,' ').replace(/\b\w/g, l => l.toUpperCase())}`,
+        title: `Slides | ${pkg.name
+          .replace(/[-]/g, ' ')
+          .replace(/\b\w/g, l => l.toUpperCase())}`,
         template: paths.assets.html,
         favicon: paths.assets.favicon,
         minify: {
@@ -65,14 +76,14 @@ module.exports = function createConfig (entry, include) {
           keepClosingSlash: true,
           minifyJS: true,
           minifyCSS: true,
-          minifyURLs: true
-        }
+          minifyURLs: true,
+        },
       }),
       new webpack.DefinePlugin({
         'process.env': {
-          'NODE_ENV': JSON.stringify(process.env.NODE_ENV)
-        }
-      })
-    ]
+          NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+        },
+      }),
+    ],
   };
 };


### PR DESCRIPTION
Because `spectacle` has a new `ComponentPlayground` (https://github.com/FormidableLabs/spectacle#component-playground) compiling presentation sources with `babel` got a little tricky. If we compile all sources there will be a `TYPED_ARRAY_SUPPORT` runtime error, because of the inclusion of `babel-standalone`.

In order to avoid this, we include only certain files and folders (users can add additional sources with `--include` since 2.0). This patch also includes "all" spectacle theme that match the following:

```js
/node_modules\/spectacle-theme-.*/
```

Ref sebald/spectacle-theme-nova#7